### PR TITLE
Fix broken specs.

### DIFF
--- a/spec/searchlight/adapters/action_view_spec.rb
+++ b/spec/searchlight/adapters/action_view_spec.rb
@@ -1,14 +1,16 @@
 require 'spec_helper'
 
-require 'searchlight/adapters/action_view'
-require 'action_view'
-require 'active_model'
-require 'active_support/core_ext'
-
 describe 'Searchlight::Adapters::ActionView', type: :feature, adapter: true do
 
   let(:view)   { ::ActionView::Base.new }
   let(:search) { AccountSearch.new(paid_amount: 15) }
+
+  before :all do
+    require 'searchlight/adapters/action_view'
+    require 'action_view'
+    require 'active_model'
+    require 'active_support/core_ext'
+  end
 
   before :each do
     view.stub(:protect_against_forgery?).and_return(false)


### PR DESCRIPTION
When I run spec file

```
rspec spec/searchlight/adapters/action_view_spec.rb
```

I have an error messages:

```
uninitialized constant Searchlight::Adapters::ActionView::ClassMethods::ActiveModel
undefined method `reverse_merge!' for {}:Hash
```

Specs passed only with some special order
