### PR TITLE
Only consider target callable if it's a proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Searchlight does its best to use [semantic versioning](http://semver.org).
 
+## Unreleased
+
+### Bugfix
+
+- Bugfix for Sequel users. Don't use `.call` unless target is a proc; avoids mistakenly using `Sequel::Dataset#call`. See [bug report](https://github.com/nathanl/searchlight/issues/25). Thanks to [Jorge Marques](https://github.com/jorge-marques) for pointing out this problem. Bug was introduced in v3.1.0.
+
 ## v3.1.0
 
 Allow callable search targets, thanks to [Adam Nowak](https://github.com/lubieniebieski).

--- a/lib/searchlight/search.rb
+++ b/lib/searchlight/search.rb
@@ -15,7 +15,8 @@ module Searchlight
     def search
       @search ||= begin
                     target = self.class.search_target
-                    if target.respond_to?(:call)
+                    if callable?(target)
+                      # for delayed scope evaluation
                       target.call
                     else
                       target
@@ -82,6 +83,12 @@ module Searchlight
       return true if value.respond_to?(:empty?) && value.empty?
       return true if value.nil? || value.to_s.strip == ''
       false
+    end
+
+    def callable?(target)
+      # The obvious implementation would be 'respond_to?(:call)`, but
+      # then we may use Sequel::Dataset#call by accident.
+      target.is_a?(Proc)
     end
 
     MissingSearchTarget = Class.new(Searchlight::Error)

--- a/spec/searchlight/search_spec.rb
+++ b/spec/searchlight/search_spec.rb
@@ -186,7 +186,7 @@ describe Searchlight::Search do
 
   describe "search_on" do
 
-    context "when an explicit, non-callable search target was provided" do
+    context "when an explicit search target was provided and it's not a proc" do
 
       let(:example_search_target) { "Bobby Fischer" }
 
@@ -210,7 +210,7 @@ describe Searchlight::Search do
 
     end
 
-    context "when an explicit, callable search target was provided" do
+    context "when an explicit search target was provided and it is a proc" do
 
       it "calls it in the process of producing search results" do
         search = ProcSearch.new(first_name: "Jimmy")


### PR DESCRIPTION
Sequel::Dataset implements the .call method but it means
something different.
http://sequel.jeremyevans.net/rdoc/classes/Sequel/Dataset.html#method-i-call

This conditional is only meant to support delayed scope evaluation,
so checking whether the target is a Proc is more what we're after.

Intended to fix https://github.com/nathanl/searchlight/issues/25
