### PR TITLE
Do not remove empty values in a non-empty Array.

### DIFF
--- a/lib/searchlight/options.rb
+++ b/lib/searchlight/options.rb
@@ -18,7 +18,8 @@ module Searchlight::Options
         output[key] = value.reject { |_, v| empty?(v) }
       end
       if value.instance_of?(Array)
-        output[key] = value.reject { |v| empty?(v) }
+        # output[key] = value.reject { |v| empty?(v) } # Do not remove empty values in a non-empty Array. FIXME: Make this an option or configurable.
+        output[key] = nil if output[key].all?(&:blank?) # If Array is entirely empty (i.e. `nil` or empty Strings only) then remove it.
       end
     end
     output.reject { |_, value| empty?(value) }


### PR DESCRIPTION
Hey @nathanl, 

Wanted to get your feedback on this.

After upgrading from v3 to v4, we noticed some of our searches were not working.

We use an Array for date ranges, first element is Start Date and second element is End Date. We also allow for open-ended date ranges by leaving one of those `nil`.

So it would look like this for >= Jan 1, 2024: 

```ruby
options[ :created_between ] = [ "Jan 1, 2024", nil ]
```

In v3 and before, that `nil` value would be left in there. 

In v4, that `nil` value is being removed and the Array becomes `[ "Jan 1, 2024" ]`.

This occurs in the `excluding_empties` method: 

```ruby
if value.instance_of?(Array)
  output[key] = value.reject { |v| empty?(v) }
end
```

Our thinking is to only reject an Array that is completely empty or filled with `nil` or empty Strings `""`.

We forked it to look something like this: 

```ruby
if value.instance_of?(Array)
  output[key] = nil if output[key].all?(&:blank?) # If Array is entirely empty (i.e. `nil` or empty Strings only) then remove it.
end
```

Two things: 

1. Was this an intentional change from v3 to v4? If not, we can restore how it worked.
2. If this was intentional then would you be open to a config to change the behaviour here and to avoid removing `blank?` values from a non-blank Array?

We're using our fork for now so no rush but let me know your thoughts. 

Thanks.